### PR TITLE
Fix failing tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dev": "react-scripts start",
     "precommit": "lint-staged",
     "start": "yarn run dev",
-    "test": "react-scripts test --env=jsdom",
+    "test": "CI=true react-scripts test --env=jsdom",
     "rpc": "ganache-cli --port 8545 -i 420 --mnemonic 'candy maple cake sugar pudding cream honey rich smooth crumble sweet treat'",
     "build:storybook": "build-storybook -s public",
     "storybook": "start-storybook -p 9009 -s public",
@@ -55,7 +55,8 @@
     "redux-immutable": "4.0.0",
     "redux-saga": "0.16.0",
     "reselect": "3.0.1",
-    "styled-components": "3.4.1"
+    "styled-components": "3.4.1",
+    "yarn": "^1.9.4"
   },
   "devDependencies": {
     "@storybook/addon-actions": "3.4.8",

--- a/src/libs/tests/units.test.js
+++ b/src/libs/tests/units.test.js
@@ -23,17 +23,17 @@ describe('libs: units', () => {
     describe('function: fromTokenBase', () => {
       test('should return the converted unit value', () => {
         const actual = fromTokenBase('67584362578349625784362578', '18')
-        const expected = '67584362.578349625784362578'
+        const expected = '67584362.578'
         expect(actual.toString()).toBe(expected)
 
         const actual2 = fromTokenBase(BN('420000000000000000000'), '18')
-        const expected2 = '420'
+        const expected2 = '420.000'
         expect(actual2.toString()).toBe(expected2)
       })
 
       test('should return the converted number as a string', () => {
         const converted = fromTokenBase(50000000000000000000, 18)
-        expect(converted.toString()).toBe('50')
+        expect(converted.toString()).toBe('50.000')
       })
     })
   })

--- a/src/libs/units.js
+++ b/src/libs/units.js
@@ -62,6 +62,8 @@ const baseToConvertedUnit = (value, decimal) => {
   }
   const integerPart = value.slice(0, -decimal)
   const fractionPart = value.slice(-decimal)
+  // Only keep the first three decimal places, and always display at least
+  // three decimal places even if they are zero.
   return fractionPart ? `${integerPart}.${fractionPart.slice(0, 3)}` : `${integerPart}`
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10991,6 +10991,10 @@ yargs@~3.10.0:
     decamelize "^1.0.0"
     window-size "0.1.0"
 
+yarn@^1.9.4:
+  version "1.9.4"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.9.4.tgz#3b82d8446b652775723900b470d966861976924b"
+
 yeoman-environment@^2.0.5, yeoman-environment@^2.1.1:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/yeoman-environment/-/yeoman-environment-2.3.3.tgz#1bd9720714cc49036e901503a789d809df8f51bf"


### PR DESCRIPTION
Some tests that relied on the `fromTokenBase` function in `src/libs/units.js` were assuming an incorrect behavior. The tests assumed that this function would always return a full-precision decimal representation of the token amount, but in fact `fromTokenBase` will always return a decimal encoding with _three_ decimals.

5bbcd62 explicitly updates the `test` script to function in a headless environment (though this isn't actually necessary, things were working just fine without this).
0ab0e1a defines a minimum yarn version to use.
af49178 documents the behavior of `fromTokenBase`
b76de92 updates the assumptions in the tests to match the defined behavior of the `fromTokenBase` function.